### PR TITLE
[Issue 203] Check bundle bitstreams has entry before getting and other fixes

### DIFF
--- a/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -266,28 +266,32 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     }
                     break;
                 case "THUMBNAIL":
-                    Bitstream thumbnailBitstream = bundle.getBitstreams().get(0);
-                    if (thumbnailBitstream != null) {
-                        String thumbnailName = thumbnailBitstream.getName();
-                        int thumbnailSequence = thumbnailBitstream.getSequenceID();
-                        String thumbnailUrl = String.format(
-                                              bitstreamUrlTemplate,
-                                              dspaceUrl,
-                                              handle,
-                                              thumbnailName,
-                                              thumbnailSequence
-                                            );
-                        doc.addField("thumbnailBitstream_stored", thumbnailUrl);
+                    if (!bundle.getBitstreams().isEmpty()) {
+                        Bitstream thumbnailBitstream = bundle.getBitstreams().get(0);
+                        if (thumbnailBitstream != null) {
+                            String thumbnailName = thumbnailBitstream.getName();
+                            int thumbnailSequence = thumbnailBitstream.getSequenceID();
+                            String thumbnailUrl = String.format(
+                                                bitstreamUrlTemplate,
+                                                dspaceUrl,
+                                                handle,
+                                                thumbnailName,
+                                                thumbnailSequence
+                                                );
+                            doc.addField("thumbnailBitstream_stored", thumbnailUrl);
+                        }
                     }
                     break;
                 case "LICENSE":
-                    Bitstream licenseBitstream = bundle.getBitstreams().get(0);
-                    if (licenseBitstream != null) {
-                        String licenseName = licenseBitstream.getName();
-                        int licenseSequence = licenseBitstream.getSequenceID();
-                        String licenseUrl = String.format(
-                                            bitstreamUrlTemplate, dspaceUrl, handle, licenseName, licenseSequence);
-                        doc.addField("licenseBitstream_stored", licenseUrl);
+                    if (!bundle.getBitstreams().isEmpty()) {
+                        Bitstream licenseBitstream = bundle.getBitstreams().get(0);
+                        if (licenseBitstream != null) {
+                            String licenseName = licenseBitstream.getName();
+                            int licenseSequence = licenseBitstream.getSequenceID();
+                            String licenseUrl = String.format(
+                                                bitstreamUrlTemplate, dspaceUrl, handle, licenseName, licenseSequence);
+                            doc.addField("licenseBitstream_stored", licenseUrl);
+                        }
                     }
                     break;
                 default:

--- a/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -232,7 +232,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         // TAMU Customization - Write friendly community/collection names to index
         if ( !locations.isEmpty() ) {
             for (String location : locations) {
-                String field = location.startsWith("m") ? " location.comm " : " location.coll ";
+                String field = location.startsWith("m") ? "location.comm" : "location.coll";
                 String dsoName = locationToName(context,field,location.substring(1));
                 log.debug("Adding location name:" + field + ".name_stored with value:" + dsoName);
                 doc.addField(field + ".name_stored", dsoName );
@@ -241,7 +241,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         // TAMU Customization - Write bitstream URLs to index
         List<String> bitstreamLocations = new ArrayList<>();
-        String dspaceUrl = configurationService.getProperty("dspace.url");
+        String dspaceUrl = configurationService.getProperty("dspace.server.url");
         for (Bundle bundle : item.getBundles()) {
             String bitstreamUrlTemplate = "%s/bitstream/handle/%s/%s?sequence=%d";
             String primaryInternalId = null;

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -1,0 +1,256 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.dspace.app.rest.utils.ContextUtil.obtainContext;
+import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+
+import org.apache.catalina.connector.ClientAbortException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.converter.ConverterService;
+import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.hateoas.BitstreamResource;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.rest.utils.HttpHeadersInitializer;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.dspace.disseminate.service.CitationDocumentService;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.EventService;
+import org.dspace.usage.UsageEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This is a specialized controller to provide access to the bitstream binary
+ * content
+ *
+ * The mapping for requested endpoint try to resolve a valid UUID, for example
+ * <pre>
+ * {@code
+ * https://<dspace.server.url>/api/core/bitstreams/26453b4d-e513-44e8-8d5b-395f62972eff/content
+ * }
+ * </pre>
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Tom Desair (tom dot desair at atmire dot com)
+ * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
+ */
+@RestController
+@RequestMapping("/api/" + BitstreamRest.CATEGORY + "/" + BitstreamRest.PLURAL_NAME
+    + REGEX_REQUESTMAPPING_IDENTIFIER_AS_UUID)
+public class BitstreamRestController {
+
+    private static final Logger log = org.apache.logging.log4j.LogManager
+            .getLogger(BitstreamRestController.class);
+
+    //Most file systems are configured to use block sizes of 4096 or 8192 and our buffer should be a multiple of that.
+    private static final int BUFFER_SIZE = 4096 * 10;
+
+    @Autowired
+    private BitstreamService bitstreamService;
+
+    @Autowired
+    BitstreamFormatService bitstreamFormatService;
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private CitationDocumentService citationDocumentService;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    ConverterService converter;
+
+    @Autowired
+    Utils utils;
+
+    @PreAuthorize("hasPermission(#uuid, 'BITSTREAM', 'READ')")
+    @RequestMapping( method = {RequestMethod.GET, RequestMethod.HEAD}, value = "content")
+    public ResponseEntity retrieve(@PathVariable UUID uuid, HttpServletResponse response,
+                         HttpServletRequest request) throws IOException, SQLException, AuthorizeException {
+
+
+        Context context = ContextUtil.obtainContext(request);
+
+        Bitstream bit = bitstreamService.find(context, uuid);
+        EPerson currentUser = context.getCurrentUser();
+
+        if (bit == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        }
+
+        Long lastModified = bitstreamService.getLastModified(bit);
+        BitstreamFormat format = bit.getFormat(context);
+        String mimetype = format.getMIMEType();
+        String name = getBitstreamName(bit, format);
+
+        if (StringUtils.isBlank(request.getHeader("Range"))) {
+            //We only log a download request when serving a request without Range header. This is because
+            //a browser always sends a regular request first to check for Range support.
+            eventService.fireEvent(
+                new UsageEvent(
+                    UsageEvent.Action.VIEW,
+                    request,
+                    context,
+                    bit));
+        }
+
+        try {
+            long filesize = bit.getSizeBytes();
+            Boolean citationEnabledForBitstream = citationDocumentService.isCitationEnabledForBitstream(bit, context);
+
+            HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
+                .withBufferSize(BUFFER_SIZE)
+                .withFileName(name)
+                .withChecksum(bit.getChecksum())
+                .withMimetype(mimetype)
+                .with(request)
+                .with(response);
+
+            if (lastModified != null) {
+                httpHeadersInitializer.withLastModified(lastModified);
+            }
+
+            //Determine if we need to send the file as a download or if the browser can open it inline
+            //The file will be downloaded if its size is larger than the configured threshold,
+            //or if its mimetype/extension appears in the "webui.content_disposition_format" config
+            long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold");
+            if ((dispositionThreshold >= 0 && filesize > dispositionThreshold)
+                    || checkFormatForContentDisposition(format)) {
+                httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
+            }
+
+            org.dspace.app.rest.utils.BitstreamResource bitstreamResource =
+                new org.dspace.app.rest.utils.BitstreamResource(name, uuid,
+                    currentUser != null ? currentUser.getID() : null,
+                    context.getSpecialGroupUuids(), citationEnabledForBitstream);
+
+            //We have all the data we need, close the connection to the database so that it doesn't stay open during
+            //download/streaming
+            context.complete();
+
+            //Send the data
+            if (httpHeadersInitializer.isValid()) {
+                HttpHeaders httpHeaders = httpHeadersInitializer.initialiseHeaders();
+                return ResponseEntity.ok().headers(httpHeaders).body(bitstreamResource);
+            }
+
+        } catch (ClientAbortException ex) {
+            log.debug("Client aborted the request before the download was completed. " +
+                          "Client is probably switching to a Range request.", ex);
+        } catch (Exception e) {
+            throw e;
+        }
+        return null;
+    }
+
+    private String getBitstreamName(Bitstream bit, BitstreamFormat format) {
+        String name = bit.getName();
+        if (name == null) {
+            // give a default name to the file based on the UUID and the primary extension of the format
+            name = bit.getID().toString();
+            if (format != null && format.getExtensions() != null && format.getExtensions().size() > 0) {
+                name += "." + format.getExtensions().get(0);
+            }
+        }
+        return name;
+    }
+
+    private boolean isNotAnErrorResponse(HttpServletResponse response) {
+        Response.Status.Family responseCode = Response.Status.Family.familyOf(response.getStatus());
+        return responseCode.equals(Response.Status.Family.SUCCESSFUL)
+            || responseCode.equals(Response.Status.Family.REDIRECTION);
+    }
+
+    private boolean checkFormatForContentDisposition(BitstreamFormat format) {
+        // never automatically download undefined formats
+        if (format == null) {
+            return false;
+        }
+        List<String> formats = List.of((configurationService.getArrayProperty("webui.content_disposition_format")));
+        boolean download = formats.contains(format.getMIMEType());
+        if (!download) {
+            for (String ext : format.getExtensions()) {
+                if (formats.contains(ext)) {
+                    download = true;
+                    break;
+                }
+            }
+        }
+        return download;
+    }
+
+    /**
+     * This method will update the bitstream format of the bitstream that corresponds to the provided bitstream uuid.
+     *
+     * @param uuid The UUID of the bitstream for which to update the bitstream format
+     * @param request  The request object
+     * @return The wrapped resource containing the bitstream which in turn contains the bitstream format
+     * @throws SQLException       If something goes wrong in the database
+     */
+    @RequestMapping(method = PUT, consumes = {"text/uri-list"}, value = "format")
+    @PreAuthorize("hasPermission(#uuid, 'BITSTREAM','WRITE')")
+    @PostAuthorize("returnObject != null")
+    public BitstreamResource updateBitstreamFormat(@PathVariable UUID uuid,
+                                                   HttpServletRequest request) throws SQLException {
+
+        Context context = obtainContext(request);
+
+        List<BitstreamFormat> bitstreamFormats = utils.constructBitstreamFormatList(request, context);
+
+        if (bitstreamFormats.size() > 1) {
+            throw new DSpaceBadRequestException("Only one bitstream format is allowed");
+        }
+
+        BitstreamFormat bitstreamFormat = bitstreamFormats.stream().findFirst()
+                .orElseThrow(() -> new DSpaceBadRequestException("No valid bitstream format was provided"));
+
+        Bitstream bitstream = bitstreamService.find(context, uuid);
+
+        if (bitstream == null) {
+            throw new ResourceNotFoundException("Bitstream with id: " + uuid + " not found");
+        }
+
+        bitstream.setFormat(context, bitstreamFormat);
+
+        context.commit();
+
+        BitstreamRest bitstreamRest = converter.toRest(context.reloadEntity(bitstream), utils.obtainProjection());
+        return converter.toResource(bitstreamRest);
+    }
+}

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -167,6 +167,13 @@ public class BitstreamRestController {
             //Send the data
             if (httpHeadersInitializer.isValid()) {
                 HttpHeaders httpHeaders = httpHeadersInitializer.initialiseHeaders();
+
+                // TAMU Customization - only return headers for HEAD request
+                if ("HEAD".equals(request.getMethod())) {
+                    log.debug("HEAD request - no response body");
+                    return ResponseEntity.ok().headers(httpHeaders).build();
+                }
+
                 return ResponseEntity.ok().headers(httpHeaders).body(bitstreamResource);
             }
 

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -1,0 +1,263 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.utils;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static javax.mail.internet.MimeUtility.encodeText;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tomcat.util.http.FastHttpDateFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * This class takes data from the Bitstream/File that has to be send. It'll then digest this input and save it in
+ * its local variables.
+ * When calling {{@link #initialiseHeaders()}}, the input and information will be used to set the proper headers
+ * with this info and return an Object of {@link HttpHeaders} to be used in the response that'll be generated
+ */
+public class HttpHeadersInitializer {
+
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private static final String METHOD_HEAD = "HEAD";
+    private static final String MULTIPART_BOUNDARY = "MULTIPART_BYTERANGES";
+    private static final String CONTENT_TYPE_MULTITYPE_WITH_BOUNDARY = "multipart/byteranges; boundary=" +
+        MULTIPART_BOUNDARY;
+    public static final String CONTENT_DISPOSITION_INLINE = "inline";
+    public static final String CONTENT_DISPOSITION_ATTACHMENT = "attachment";
+    private static final String IF_NONE_MATCH = "If-None-Match";
+    private static final String IF_MODIFIED_SINCE = "If-Modified-Since";
+    private static final String ETAG = "ETag";
+    private static final String IF_MATCH = "If-Match";
+    private static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String ACCEPT_RANGES = "Accept-Ranges";
+    private static final String BYTES = "bytes";
+    private static final String LAST_MODIFIED = "Last-Modified";
+    private static final String EXPIRES = "Expires";
+    private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+    private static final String IMAGE = "image";
+    private static final String ACCEPT = "Accept";
+    private static final String CONTENT_DISPOSITION = "Content-Disposition";
+    private static final String CONTENT_DISPOSITION_FORMAT = "%s;filename=\"%s\"";
+    private static final String CACHE_CONTROL = "Cache-Control";
+
+    private int bufferSize = 1000000;
+
+    private static final long DEFAULT_EXPIRE_TIME = 60L * 60L * 1000L;
+
+    //no-cache so request is always performed for logging
+    private static final String CACHE_CONTROL_SETTING = "private,no-cache";
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private String contentType;
+    private String disposition;
+    private long lastModified;
+    private long length;
+    private String fileName;
+    private String checksum;
+
+    public HttpHeadersInitializer() {
+        //Convert to BufferedInputStream so we can re-read the stream
+    }
+
+    public HttpHeadersInitializer with(HttpServletRequest httpRequest) {
+        request = httpRequest;
+        return this;
+    }
+
+    public HttpHeadersInitializer with(HttpServletResponse httpResponse) {
+        response = httpResponse;
+        return this;
+    }
+
+    public HttpHeadersInitializer withLength(long length) {
+        this.length = length;
+        return this;
+    }
+
+    public HttpHeadersInitializer withFileName(String fileName) {
+        this.fileName = fileName;
+        return this;
+    }
+
+    public HttpHeadersInitializer withChecksum(String checksum) {
+        this.checksum = checksum;
+        return this;
+    }
+
+    public HttpHeadersInitializer withMimetype(String mimetype) {
+        this.contentType = mimetype;
+        return this;
+    }
+
+    public HttpHeadersInitializer withLastModified(long lastModified) {
+        this.lastModified = lastModified;
+        return this;
+    }
+
+    public HttpHeadersInitializer withBufferSize(int bufferSize) {
+        if (bufferSize > 0) {
+            this.bufferSize = bufferSize;
+        }
+        return this;
+    }
+    public HttpHeadersInitializer withDisposition(String contentDisposition) {
+        this.disposition = contentDisposition;
+        return this;
+    }
+
+    /**
+     * This method will be called to create a {@link HttpHeaders} object which will contain the headers needed
+     * to form a proper response when returning the Bitstream/File
+     * @return  A {@link HttpHeaders} object containing the information for the Bitstream/File to be sent
+     * @throws IOException If something goes wrong
+     */
+    public HttpHeaders initialiseHeaders() throws IOException {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        // Validate and process range -------------------------------------------------------------
+
+        log.debug("Content-Type : {}", contentType);
+        //TODO response.reset() => Can be re-instated/investigated once we upgrade to Spring 5.2.9, see issue #3056
+        // Initialize response.
+        response.setBufferSize(bufferSize);
+        if (contentType != null) {
+            httpHeaders.put(CONTENT_TYPE, Collections.singletonList(contentType));
+        }
+        httpHeaders.put(ACCEPT_RANGES, Collections.singletonList(BYTES));
+        if (checksum != null) {
+            httpHeaders.put(ETAG, Collections.singletonList(checksum));
+        }
+        httpHeaders.put(LAST_MODIFIED, Collections.singletonList(FastHttpDateFormat.formatDate(lastModified)));
+        httpHeaders.put(EXPIRES, Collections.singletonList(FastHttpDateFormat.formatDate(
+            System.currentTimeMillis() + DEFAULT_EXPIRE_TIME)));
+
+        //No-cache so that we can log every download
+        httpHeaders.put(CACHE_CONTROL, Collections.singletonList(CACHE_CONTROL_SETTING));
+
+        if (isNullOrEmpty(disposition)) {
+            if (contentType == null) {
+                contentType = APPLICATION_OCTET_STREAM;
+            } else if (!contentType.startsWith(IMAGE)) {
+                String accept = request.getHeader(ACCEPT);
+                disposition = accept != null && accepts(accept,
+                                                        contentType) ? CONTENT_DISPOSITION_INLINE :
+                    CONTENT_DISPOSITION_ATTACHMENT;
+            }
+
+        }
+
+        httpHeaders.put(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                        Collections.singletonList(HttpHeaders.ACCEPT_RANGES));
+        httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
+                                                                                     disposition,
+                                                                                     encodeText(fileName))));
+        log.debug("Content-Disposition : {}", disposition);
+
+        // Content phase
+        if (METHOD_HEAD.equals(request.getMethod())) {
+            log.debug("HEAD request - skipping content");
+            return null;
+        }
+
+        return httpHeaders;
+
+    }
+
+    /**
+     * This method will validate whether or not the given Response/Request/Information/Variables are valid.
+     * If they're invalid, the Response shouldn't be given.
+     * This will do null checks on the response, request, inputstream and filename.
+     * Other than this, it'll check Request headers to see if their information is correct.
+     * @return
+     * @throws IOException
+     */
+    public boolean isValid() throws IOException {
+        if (response == null || request == null) {
+            return false;
+        }
+
+        if (StringUtils.isEmpty(fileName)) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return false;
+        }
+
+        // Validate request headers for caching ---------------------------------------------------
+        // If-None-Match header should contain "*" or ETag. If so, then return 304.
+        String ifNoneMatch = request.getHeader(IF_NONE_MATCH);
+        if (nonNull(ifNoneMatch) && matches(ifNoneMatch, checksum)) {
+            log.debug("If-None-Match header should contain \"*\" or ETag. If so, then return 304.");
+            response.setHeader(ETAG, checksum); // Required in 304.
+            response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+            return false;
+        }
+
+        // If-Modified-Since header should be greater than LastModified. If so, then return 304.
+        // This header is ignored if any If-None-Match header is specified.
+        long ifModifiedSince = request.getDateHeader(IF_MODIFIED_SINCE);
+        if (isNull(ifNoneMatch) && ifModifiedSince != -1 && ifModifiedSince + 1000 > lastModified) {
+            log.debug("If-Modified-Since header should be greater than LastModified. If so, then return 304.");
+            response.setHeader(ETAG, checksum); // Required in 304.
+            response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+            return false;
+        }
+
+        // Validate request headers for resume ----------------------------------------------------
+
+        // If-Match header should contain "*" or ETag. If not, then return 412.
+        String ifMatch = request.getHeader(IF_MATCH);
+        if (nonNull(ifMatch) && !matches(ifMatch, checksum)) {
+            log.error("If-Match header should contain \"*\" or ETag. If not, then return 412.");
+            response.sendError(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
+            return false;
+        }
+
+        // If-Unmodified-Since header should be greater than LastModified. If not, then return 412.
+        long ifUnmodifiedSince = request.getDateHeader(IF_UNMODIFIED_SINCE);
+        if (ifUnmodifiedSince != -1 && ifUnmodifiedSince + 1000 <= lastModified) {
+            log.error("If-Unmodified-Since header should be greater than LastModified. If not, then return 412.");
+            response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED);
+            return false;
+        }
+
+        return true;
+    }
+
+
+    private static boolean isNullOrEmpty(String disposition) {
+        return StringUtils.isBlank(disposition);
+    }
+
+
+    private static boolean accepts(String acceptHeader, String toAccept) {
+        String[] acceptValues = acceptHeader.split("\\s*(,|;)\\s*");
+        Arrays.sort(acceptValues);
+
+        return Arrays.binarySearch(acceptValues, toAccept) > -1
+            || Arrays.binarySearch(acceptValues, toAccept.replaceAll("/.*$", "/*")) > -1
+            || Arrays.binarySearch(acceptValues, "*/*") > -1;
+    }
+
+    private static boolean matches(String matchHeader, String toMatch) {
+        String[] matchValues = matchHeader.split("\\s*,\\s*");
+        Arrays.sort(matchValues);
+        return Arrays.binarySearch(matchValues, toMatch) > -1 || Arrays.binarySearch(matchValues, "*") > -1;
+    }
+
+}

--- a/dspace/modules/server/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace/modules/server/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -165,16 +165,24 @@ public class HttpHeadersInitializer {
 
         httpHeaders.put(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
                         Collections.singletonList(HttpHeaders.ACCEPT_RANGES));
-        httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
-                                                                                     disposition,
-                                                                                     encodeText(fileName))));
+        // TAMU Customization - without knowing details only add Content-Disposition header if disposition defined
+        // httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
+        //                                                                              disposition,
+        //                                                                              encodeText(fileName))));
+        if (!isNullOrEmpty(disposition)) {
+            httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
+                                                                                         disposition,
+                                                                                         encodeText(fileName))));
+        }
+
         log.debug("Content-Disposition : {}", disposition);
 
         // Content phase
-        if (METHOD_HEAD.equals(request.getMethod())) {
-            log.debug("HEAD request - skipping content");
-            return null;
-        }
+        // TAMU Customization - return headers regardless of request verb
+        // if (METHOD_HEAD.equals(request.getMethod())) {
+        //     log.debug("HEAD request - skipping content");
+        //     return null;
+        // }
 
         return httpHeaders;
 


### PR DESCRIPTION
Branched from `223-bitstream-content-type` as `dspace-7_x-sprint4` and `dspace-7_x-sprint4-staging` are currently not deployable. Please review and merge #224 before this PR.

Resolves below stack trace.

It appears the backing collection implementation of the bundle's bitstreams may have changed. The get method now throws out of bounds exception as opposed to returning null.

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:361)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at org.dspace.discovery.SolrServiceImpl.addCommunityCollectionItem(SolrServiceImpl.java:269)
	at org.dspace.discovery.SolrServiceImpl.update(SolrServiceImpl.java:181)
	at org.dspace.discovery.SolrServiceImpl.indexContent(SolrServiceImpl.java:169)
	at org.dspace.discovery.SolrServiceImpl.updateIndex(SolrServiceImpl.java:487)
	at org.dspace.discovery.SolrServiceImpl.updateIndex(SolrServiceImpl.java:474)
	at org.dspace.discovery.IndexClient.internalRun(IndexClient.java:136)
	at org.dspace.scripts.DSpaceRunnable.run(DSpaceRunnable.java:150)
	at org.dspace.app.launcher.ScriptLauncher.executeScript(ScriptLauncher.java:154)
	at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:132)
	at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:99)
```