### PR TITLE
[Issue 243] Add extraction step to submission processes

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -322,7 +322,7 @@
             <!--Step will be to Upload the item -->
             <step id="upload"/>
 
-            <!-- <step id="extractionstep"/> -->
+            <step id="extractionstep"/>
 
             <!-- Uncomment this step to allow the user to select a Creative Commons License -->
             <step id="cclicense"/>
@@ -354,7 +354,7 @@
             <!--Step will be to Upload the item -->
             <step id="upload"/>
 
-            <!-- <step id="extractionstep"/> -->
+            <step id="extractionstep"/>
 
             <!-- Uncomment this step to allow the user to select a Creative Commons License -->
             <step id="cclicense"/>
@@ -386,7 +386,7 @@
             <!--Step will be to Upload the item -->
             <step id="upload"/>
 
-            <!-- <step id="extractionstep"/> -->
+            <step id="extractionstep"/>
 
             <!-- Uncomment this step to allow the user to select a Creative Commons License -->
             <step id="cclicense"/>
@@ -418,7 +418,7 @@
             <!--Step will be to Upload the item -->
             <step id="upload"/>
 
-            <!-- <step id="extractionstep"/> -->
+            <step id="extractionstep"/>
 
             <!-- Uncomment this step to allow the user to select a Creative Commons License -->
             <step id="cclicense"/>


### PR DESCRIPTION
Resolves #243

This enables the `ExtractMetdataStep` and allows to start a submission with a RIS (with extension .ris) or BibTeX (with extension .bib or .bibtex) citation files.

The EndNote import service is enabled but have not been successful with any EndNote (with extension .enl or .enw) citations so far.