### PR TITLE
Add null checks to SolrServiceFileInfoPlugin and SolrServiceImpl

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -52,21 +52,24 @@ public class SolrServiceFileInfoPlugin implements SolrServiceIndexPlugin {
                         List<Bitstream> bitstreams = bundle.getBitstreams();
                         if (bitstreams != null) {
                             for (Bitstream bitstream : bitstreams) {
-                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
-                                // Add _keyword and _filter fields which are necessary to support filtering and faceting
-                                // for the file names
-                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_keyword", bitstream.getName());
-                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_filter", bitstream.getName());
+                                if (bitstream != null)
+                                {
+                                    document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
+                                    // Add _keyword and _filter fields which are necessary to support filtering and faceting
+                                    // for the file names
+                                    document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_keyword", bitstream.getName());
+                                    document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_filter", bitstream.getName());
 
-                                String description = bitstream.getDescription();
-                                if ((description != null) && !description.isEmpty()) {
-                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS, description);
-                                    // Add _keyword and _filter fields which are necessary to support filtering and
-                                    // faceting for the descriptions
-                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_keyword",
-                                                      description);
-                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_filter",
-                                                      description);
+                                    String description = bitstream.getDescription();
+                                    if ((description != null) && !description.isEmpty()) {
+                                        document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS, description);
+                                        // Add _keyword and _filter fields which are necessary to support filtering and
+                                        // faceting for the descriptions
+                                        document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_keyword",
+                                                        description);
+                                        document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_filter",
+                                                        description);
+                                    }
                                 }
                             }
                         }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -52,8 +52,7 @@ public class SolrServiceFileInfoPlugin implements SolrServiceIndexPlugin {
                         List<Bitstream> bitstreams = bundle.getBitstreams();
                         if (bitstreams != null) {
                             for (Bitstream bitstream : bitstreams) {
-                                if (bitstream != null)
-                                {
+                                if (bitstream != null) {
                                     document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
                                     // Add _keyword and _filter fields which are necessary to support filtering and faceting
                                     // for the file names

--- a/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -257,7 +257,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         doc.addField("primaryBitstream_stored", primaryUrl);
                     }
                     for (Bitstream bitstream : bundle.getBitstreams()) {
-                        if (bitstream.getInternalId() != null && !bitstream.getInternalId().equals(primaryInternalId)) {
+                        if (bitstream != null && bitstream.getInternalId() != null && !bitstream.getInternalId().equals(primaryInternalId)) {
                             String name = bitstream.getName();
                             int sequence = bitstream.getSequenceID();
                             String url = String.format(bitstreamUrlTemplate, dspaceUrl, handle, name, sequence);


### PR DESCRIPTION
## References

- [Issue 315](https://github.com/TAMULib/DSpace/issues/315)
- Related DSpace Google Group post: https://groups.google.com/g/dspace-tech/c/Zey_-scOsqc/m/CcXy13rVCgAJ

## Description
Add null checks in:
- `/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java`
- `/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java`

**Include guidance for how to test or review your PR.**
With a known item that contains a null bitstream, running the following command **without** the added null checks will produce the stacktrace stated in [Issue 315](https://github.com/TAMULib/DSpace/issues/315), while **with** the null checks will successfully index.

`/dspace/bin/dspace index-discovery -i 9b6a2cd4-d1b5-41ff-a065-abffb7d8d9e3`

Item link: https://oaktrust.library.tamu.edu/items/9b6a2cd4-d1b5-41ff-a065-abffb7d8d9e3