### PR TITLE
Add bitstream null check to XOAI.java

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -110,7 +110,7 @@ public class XOAI {
         try {
             for (Bundle b : itemService.getBundles(item, "ORIGINAL")) {
                 for (Bitstream bs : b.getBitstreams()) {
-                    if (!formats.contains(bs.getFormat(context).getMIMEType())) {
+                    if (bs != null && !formats.contains(bs.getFormat(context).getMIMEType())) {
                         formats.add(bs.getFormat(context).getMIMEType());
                     }
                 }


### PR DESCRIPTION
## References
Related upstream [PR](https://github.com/DSpace/DSpace/pull/10511) and [Issue](https://github.com/DSpace/DSpace/issues/10510)

## Description
Same as the [index-discovery PR](https://github.com/TAMULib/DSpace/pull/316), if a bitstream is corrupt/null, it will break the `oai import` daily cron job and prevent it from further processing other items, until the item is found and fixed. Afaik there is no explicit notification of a null bitstream until it gets found either via UI or when someone looks at the cron logs and notices the stack trace, and the import of new items would be blocked by this bad bitstream in the meantime until it's fixed or skipped. A null bitstream would also stop a fresh oai import, index-discovery, and sitemap generation using:
- `/dspace/bin/dspace oai import -c`
- `/dspace/bin/dspace index-discovery -b`
- `/dspace/bin/dspace generate-sitemaps -d`

because it will stop at that bad item.


Stack trace:
```
[dspace]/bin/dspace oai import
OAI 2.0 manager action started
Incremental import. Searching for documents modified after:
java.lang.NullPointerException: Cannot invoke "org.dspace.content.Bitstream.getFormat(org.dspace.core.Context)" because "bs" is null
        at org.dspace.xoai.app.XOAI.getFileFormats(XOAI.java:113)
        at org.dspace.xoai.app.XOAI.index(XOAI.java:467)
        at org.dspace.xoai.app.XOAI.index(XOAI.java:320)
        at org.dspace.xoai.app.XOAI.index(XOAI.java:194)
        at org.dspace.xoai.app.XOAI.index(XOAI.java:168)
        at org.dspace.xoai.app.XOAI.main(XOAI.java:618)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:283)
        at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:134)
        at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:99)
```
