### PR TITLE
Add null check to sitemap generation

### DIFF
--- a/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1173,8 +1173,12 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         // Add information about our search fields
                         for (String field : searchFields) {
                             List<String> valuesAsString = new ArrayList<>();
-                            for (Object o : doc.getFieldValues(field)) {
-                                valuesAsString.add(String.valueOf(o));
+                            var fieldValues = doc.getFieldValues(field);
+                            if (fieldValues != null)
+                            {
+                                for (Object o : fieldValues) {
+                                    valuesAsString.add(String.valueOf(o));
+                                }
                             }
                             resultDoc.addSearchField(field, valuesAsString.toArray(new String[valuesAsString.size()]));
                         }


### PR DESCRIPTION
## Description

Similar to the following null checks:

- [Add bitstream null check to XOAI.java](https://github.com/TAMULib/DSpace/pull/317)
- [Add null checks to SolrServiceFileInfoPlugin and SolrServiceImpl](https://github.com/TAMULib/DSpace/pull/316)

When `doc.getFieldValues(field)` returns a null set of `fieldValues`, it'd produce the following stack trace and prevent the sitemaps from being generated:

```
Exception: org.dspace.discovery.SearchServiceException: Cannot invoke "java.util.Collection.iterator()" because the return value of "org.apache.solr.common.SolrDocument.getFieldValues(String)" is null
java.lang.RuntimeException: org.dspace.discovery.SearchServiceException: Cannot invoke "java.util.Collection.iterator()" because the return value of "org.apache.solr.common.SolrDocument.getFieldValues(String)" is null
	at org.dspace.app.sitemap.GenerateSitemaps.generateSitemaps(GenerateSitemaps.java:288)
    at org.dspace.app.sitemap.GenerateSitemaps.main(GenerateSitemaps.java:117)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:283)
 	at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:134)
 	at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:99)
Caused by: org.dspace.discovery.SearchServiceException: Cannot invoke "java.util.Collection.iterator()" because the return value of "org.apache.solr.common.SolrDocument.getFieldValues(String)" is null
 	at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:916)
 	at org.dspace.app.sitemap.GenerateSitemaps.generateSitemaps(GenerateSitemaps.java:245)
 	... 8 more
 Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Collection.iterator()" because the return value of "org.apache.solr.common.SolrDocument.getFieldValues(String)" is null
 	at org.dspace.discovery.SolrServiceImpl.retrieveResult(SolrServiceImpl.java:1176)
 	at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:913)
 	... 9 more
```