### PR TITLE
OIDC Special Group Mapping

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -380,6 +380,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Use version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -384,7 +384,6 @@
             <artifactId>spring-boot-starter-security</artifactId>
             <version>${spring-boot.version}</version>
             <exclusions>
-                <!-- Use version brought in by spring-boot-starter-web above -->
                 <exclusion>
                     <groupId>io.micrometer</groupId>
                     <artifactId>micrometer-observation</artifactId>

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -16,6 +16,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,9 @@ import org.dspace.authenticate.oidc.model.OidcTokenResponseDTO;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -48,6 +51,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class OidcAuthenticationBean implements AuthenticationMethod {
 
     public static final String OIDC_AUTH_ATTRIBUTE = "oidc";
+
+    protected GroupService groupService
+            = EPersonServiceFactory.getInstance().getGroupService();
 
     private final static String LOGIN_PAGE_URL_FORMAT = "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s";
 
@@ -85,6 +91,26 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) throws SQLException {
+        // Check if authentication-oidc.login.specialgroup config has a group defined
+        try {
+            // without a logged in user, this method should return an empty list
+            if (context.getCurrentUser() == null) {
+                return List.of();
+            }
+            String groupName = configurationService.getProperty("authentication-oidc.login.specialgroup");
+            if ((groupName != null) && (!groupName.trim().equals(""))) {
+                Group group = groupService.findByName(context, groupName);
+                if (group == null) {
+                    // Group not found
+                    LOGGER.warn("Group defined in authentication-oidc.login.specialgroup does not exist");
+                    return List.of();
+                } else {
+                    return Arrays.asList(group);
+                }
+            }
+        } catch (SQLException ex) {
+            // Database error, ignore
+        }
         return List.of();
     }
 
@@ -141,9 +167,16 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         if (! canSelfRegister()) {
             LOGGER.warn("Self registration is currently disabled for OIDC, and no ePerson could be found for email: {}",
                 email);
+            return NO_SUCH_USER;
+        } else {
+            int result = registerNewEPerson(context, userInfo, email);
+            if (result == SUCCESS) {
+                // It is important to set this attribute so the new user
+                // can be granted permissions of the special group in the first login
+                request.setAttribute(OIDC_AUTHENTICATED, true);
+            }
+            return result;
         }
-
-        return canSelfRegister() ? registerNewEPerson(context, userInfo, email) : NO_SUCH_USER;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -102,6 +102,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     @Override
     public void initEPerson(Context context, HttpServletRequest request, EPerson eperson) throws SQLException {
+        // do nothing
     }
 
     @Override
@@ -117,6 +118,12 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                 if (context.getSpecialGroups().size() > 0 ) {
                     LOGGER.info("Returning cached special groups.");
                     return context.getSpecialGroups();
+                }
+
+                String code = (String) request.getParameter("code");
+                if (StringUtils.isEmpty(code)) {
+                    LOGGER.warn("The incoming request does not have a code parameter");
+                    return NO_SUCH_USER;
                 }
 
                 printRequestDetails(request);
@@ -149,7 +156,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                 }
             }
         } catch (SQLException ex) {
-            // Ignoring database error
+            // ignoring database error
         }
 
         return groups;

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -180,6 +180,11 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                 LOGGER.info("Determining Special Groups (request context) " + groupNames);
             }
 
+            if (groupNames.isEmpty()) {
+                groupNames = (Set<String>) request.getAttribute("specialgroups");
+                LOGGER.info("Determining Special Groups (request context) " + groupNames);
+            }
+
             for (String groupName : groupNames) {
                 if (groupName == null || groupName.isEmpty()) {
                     continue;
@@ -638,23 +643,96 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     private static void printRequestDetails(HttpServletRequest request) {
         LOGGER.info("=== HTTP SERVLET REQUEST DETAILS ===");
 
-        LOGGER.info("--- ATTRIBUTES ---");
+        int results = 0;
+
+        results = printRequestAttributes(request);
+        results = printRequestCookies(request);
+        results = printRequestHeaders(request);
+        results = printRequestParameters(request);
+
+        if (results < 0) {
+            LOGGER.warn(request);
+            LOGGER.info("*** EMPTY REQUEST ***");
+        }
+
+        LOGGER.info("=== END REQUEST DETAILS ===");
+    }
+
+    private static int printRequestAttributes(HttpServletRequest request) {
+        int results = 0;
         Enumeration<String> attributeNames = request.getAttributeNames();
-        if (!attributeNames.hasMoreElements()) {
-            LOGGER.info("No attributes found");
-        } else {
+        if (attributeNames.hasMoreElements()) {
+            LOGGER.info("--- ATTRIBUTES ---");
             while (attributeNames.hasMoreElements()) {
                 String attributeName = attributeNames.nextElement();
                 Object attributeValue = request.getAttribute(attributeName);
                 LOGGER.info(attributeName + " = " + attributeValue);
             }
+        } else {
+            LOGGER.info("No attributes found");
+            results = -1;
         }
 
-        LOGGER.info("--- PARAMETERS ---");
-        Enumeration<String> paramNames = request.getParameterNames();
-        if (!paramNames.hasMoreElements()) {
-            LOGGER.info("No parameters found");
+        return results;
+    }
+
+    private static int printRequestCookies(HttpServletRequest request) {
+        int results = 0;
+        Cookie[] cookies = request.getCookies();
+        boolean hasCookies = !(cookies == null || cookies.length == 0);
+        if (hasCookies) {
+            LOGGER.info("--- COOKIES ---");
+            for (Cookie cookie : cookies) {
+                LOGGER.info(cookie.getName() + " = " + cookie.getValue() +
+                    " (domain: " + cookie.getDomain() +
+                    ", path: " + cookie.getPath() +
+                    ", maxAge: " + cookie.getMaxAge() +
+                    ", secure: " + cookie.getSecure() +
+                    ", httpOnly: " + cookie.isHttpOnly() + ")");
+            }
+            
         } else {
+            LOGGER.info("No cookies found");
+            results = -1;
+        }
+
+        return results;
+    }
+
+    private static int printRequestHeaders(HttpServletRequest request) {
+        int results = 0;
+        Enumeration<String> headerNames = request.getHeaderNames();
+        if (headerNames.hasMoreElements()) {
+            LOGGER.info("--- HEADERS ---");
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                Enumeration<String> headerValues = request.getHeaders(headerName);
+
+                String message  = headerName + " = ";
+
+                boolean first = true;
+                while (headerValues.hasMoreElements()) {
+                    if (!first) {
+                        message += ", ";
+                    }
+                    message += headerValues.nextElement();
+                    first = false;
+                }
+                LOGGER.info(message);
+            }
+        } else {
+            LOGGER.info("No headers found");
+            results = -1;
+        }
+
+        return results;
+    }
+
+    private static int printRequestParameters(HttpServletRequest request) {
+        int results = 0;
+        Enumeration<String> paramNames = request.getParameterNames();
+        if (paramNames.hasMoreElements()) {
+            LOGGER.info("--- PARAMETERS ---");
             while (paramNames.hasMoreElements()) {
                 String paramName = paramNames.nextElement();
                 String[] paramValues = request.getParameterValues(paramName);
@@ -672,47 +750,12 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                     LOGGER.info(message);
                 }
             }
-        }
-
-        LOGGER.info("--- HEADERS ---");
-        Enumeration<String> headerNames = request.getHeaderNames();
-        if (!headerNames.hasMoreElements()) {
-            LOGGER.info("No headers found");
         } else {
-            while (headerNames.hasMoreElements()) {
-                String headerName = headerNames.nextElement();
-                Enumeration<String> headerValues = request.getHeaders(headerName);
-
-                String message  = headerName + " = ";
-
-                boolean first = true;
-                while (headerValues.hasMoreElements()) {
-                    if (!first) {
-                        message += ", ";
-                    }
-                    message += headerValues.nextElement();
-                    first = false;
-                }
-                LOGGER.info(message);
-            }
+            LOGGER.info("No parameters found");
+            results = -1;
         }
 
-        LOGGER.info("--- COOKIES ---");
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null || cookies.length == 0) {
-            LOGGER.info("No cookies found");
-        } else {
-            for (Cookie cookie : cookies) {
-                LOGGER.info(cookie.getName() + " = " + cookie.getValue() +
-                    " (domain: " + cookie.getDomain() +
-                    ", path: " + cookie.getPath() +
-                    ", maxAge: " + cookie.getMaxAge() +
-                    ", secure: " + cookie.getSecure() +
-                    ", httpOnly: " + cookie.isHttpOnly() + ")");
-            }
-        }
-
-        LOGGER.info("=== END REQUEST DETAILS ===");
+        return results;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -16,11 +16,21 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -36,6 +46,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -60,6 +71,8 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final String OIDC_AUTHENTICATED = "oidc.authenticated";
+
+    private static ThreadLocal<Set<String>> threadLocalGroupNames = ThreadLocal.withInitial(() -> new HashSet<>());
 
     @Autowired
     private ConfigurationService configurationService;
@@ -91,27 +104,32 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) throws SQLException {
-        // Check if authentication-oidc.login.specialgroup config has a group defined
+        final Set<String> groupNames = threadLocalGroupNames.get();
+        LOGGER.info("Determining Special Groups " + groupNames);
+
+        List<Group> groups = new ArrayList<>();
+
         try {
-            // without a logged in user, this method should return an empty list
-            if (context.getCurrentUser() == null) {
-                return List.of();
-            }
-            String groupName = configurationService.getProperty("authentication-oidc.login.specialgroup");
-            if ((groupName != null) && (!groupName.trim().equals(""))) {
-                Group group = groupService.findByName(context, groupName);
-                if (group == null) {
-                    // Group not found
-                    LOGGER.warn("Group defined in authentication-oidc.login.specialgroup does not exist");
-                    return List.of();
-                } else {
-                    return Arrays.asList(group);
+            if (context.getCurrentUser() != null && groupNames != null) {
+                for (String groupName : groupNames) {
+                    if (groupName == null || groupName.isEmpty()) {
+                        continue;
+                    }
+                    LOGGER.info("Looking Up Special Group " + groupName);
+                    Group group = groupService.findByName(context, groupName);
+                    if (group == null) {
+                        LOGGER.warn("Group {} does not exist", groupName);
+                    } else {
+                        LOGGER.info("Found Special Group " + groupName);
+                        groups.add(group);
+                    }
                 }
             }
         } catch (SQLException ex) {
-            // Database error, ignore
+            // Ignoring database error
         }
-        return List.of();
+
+        return groups;
     }
 
     @Override
@@ -122,6 +140,8 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     @Override
     public int authenticate(Context context, String username, String password, String realm, HttpServletRequest request)
         throws SQLException {
+
+        LOGGER.info("Authenticating");
 
         if (request == null) {
             LOGGER.warn("Unable to authenticate using OIDC because the request object is null.");
@@ -149,7 +169,30 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
             return NO_SUCH_USER;
         }
 
+        LOGGER.info("Access Token " + accessToken.getAccessToken());
+
+        LOGGER.info("Access Claims " + decodeJwt(accessToken.getAccessToken()));
+
+        LOGGER.info("ID Token " + accessToken.getIdToken());
+
+        Map<String, Object> claims = decodeJwt(accessToken.getIdToken()).get("payload");
+
+        LOGGER.info("ID Claims " + claims);
+
         Map<String, Object> userInfo = getOidcUserInfo(accessToken.getAccessToken());
+
+        LOGGER.info("User Info " + userInfo);
+
+        Map<String, Map<String, String[]>> groupMappings = getGroupMappings();
+
+        LOGGER.info("Group Mappings " + groupMappings);
+
+        Set<String> groups = determineGroups(groupMappings, claims);
+
+        LOGGER.info("Groups " + groups);
+
+        threadLocalGroupNames.set(groups);
+
 
         String email = getAttributeAsString(userInfo, getEmailAttribute());
         if (StringUtils.isBlank(email)) {
@@ -164,7 +207,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         }
 
         // if self registration is disabled, warn about this failure to find a matching eperson
-        if (! canSelfRegister()) {
+        if (!canSelfRegister()) {
             LOGGER.warn("Self registration is currently disabled for OIDC, and no ePerson could be found for email: {}",
                 email);
             return NO_SUCH_USER;
@@ -301,6 +344,131 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         return configurationService.getProperty("authentication-oidc.user-info.last-name", "family_name");
     }
 
+    private Map<String, Map<String, String[]>> getGroupMappings() {
+        final Map<String, Map<String, String[]>> groupMappings = new HashMap<>();
+
+        final String groupClaims = configurationService.getProperty("authentication-oidc.group.claims", "groups");
+
+        LOGGER.info("Group Claims " + groupClaims);
+
+        final String[] groupKeys = groupClaims.split(",");
+
+        for (String groupKey : groupKeys) {
+            final String claimKey = groupKey.trim();
+            LOGGER.info("Claim Key " + claimKey);
+            if (claimKey.length() > 0) {
+                groupKey = claimKey;
+
+                LOGGER.info("Group Key " + groupKey);
+                final Map<String, String[]> groupMapping = getGroupMapping(claimKey);
+                LOGGER.info("Group Mapping " + groupMapping);
+                groupMappings.put(groupKey, groupMapping);
+            }
+        }
+
+        // {claim key, {claim value, [groups]}}
+        return groupMappings;
+    }
+
+    private Map<String, String[]> getGroupMapping(String claimKey) {
+        final Map<String, String[]> groupMapping = new HashMap<>();
+
+        final String configPrefix = String.join(".", "authentication-oidc", claimKey);
+
+        LOGGER.info("Config Prefix " + configPrefix);
+
+        final List<String> claimGroupPropertyKeys = configurationService.getPropertyKeys(configPrefix);
+
+        LOGGER.info("Claim Group Property Keys " + claimGroupPropertyKeys);
+
+        for (String claimGroupPropertyKey : claimGroupPropertyKeys) {
+
+            LOGGER.info("Claim Group Property Key " + claimGroupPropertyKey);
+
+            final String[] claimGroupPropertyKeySections = claimGroupPropertyKey.split("\\.");
+
+            LOGGER.info("Claim Group Property Key Sections " + Arrays.toString(claimGroupPropertyKeySections));
+
+            if (claimGroupPropertyKeySections.length == 3) {
+
+                final String groupClaimValue = claimGroupPropertyKeySections[2];
+
+                LOGGER.info("Group Claim Value " + groupClaimValue);
+
+                final String groupClaim = configurationService.getProperty(claimGroupPropertyKey, "").trim();
+
+                LOGGER.info("Group Claim " + groupClaim);
+
+                if (groupClaim.length() > 0) {
+                    final String[] groups = groupClaim.split(",");
+
+                    LOGGER.info("Groups " + Arrays.toString(groups));
+
+                    for (String group : groups) {
+                        group = group.trim();
+                    }
+                    groupMapping.put(groupClaimValue, groups);
+                }
+            }
+        }
+
+        // {claim value, [groups]}
+        return groupMapping;
+    }
+
+    private Set<String> determineGroups(Map<String, Map<String, String[]>> groupMappings, Map<String, Object> claims) {
+        final Set<String> groups = new HashSet<>();
+
+        for (Entry<String, Object> claimEntry : claims.entrySet()) {
+            if (claimEntry.getKey() == null || claimEntry.getValue() == null) {
+                continue;
+            }
+
+            final String claimKey = claimEntry.getKey().trim();
+            final Object claimValue = claimEntry.getValue();
+
+            if (claimKey.length() > 0 && groupMappings.containsKey(claimKey)) {
+                final Map<String, String[]> groupMapping = groupMappings.get(claimKey);
+
+                for (Entry<String, String[]> groupMappingEntry : groupMapping.entrySet()) {
+                    if (groupMappingEntry.getKey() == null || groupMappingEntry.getValue() == null) {
+                        continue;
+                    }
+
+                    final String groupClaimValue = groupMappingEntry.getKey().trim();
+                    final List<String> groupsForClaim = Arrays.asList(groupMappingEntry.getValue())
+                        .stream()
+                        .map(groupForClaim -> groupForClaim.trim())
+                        .filter(groupForClaim -> groupForClaim.length() > 0)
+                        .collect(Collectors.toList());
+
+                    if (claimValue instanceof String claim) {
+                        final String[] groupClaims = claim.split(",");
+                        for (String groupClaim : groupClaims) {
+                            groupClaim = groupClaim.trim();
+                            if (groupClaim.length() > 0 && groupClaim.startsWith(groupClaimValue)) {
+                                groups.addAll(groupsForClaim);
+                            }
+                        }
+                    } else if (claimValue instanceof Collection claim) {
+                        for (Object groupsClaim : claim) {
+                            if (!(groupsClaim instanceof String)) {
+                                continue;
+                            }
+                            final String groupClaim = ((String) groupsClaim).trim();
+                            if (groupClaim.length() > 0 && groupClaim.startsWith(groupClaimValue)) {
+                                groups.addAll(groupsForClaim);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // [groups]
+        return groups;
+    }
+
     private boolean canSelfRegister() {
         String canSelfRegister = configurationService.getProperty("authentication-oidc.can-self-register", "true");
         if (isBlank(canSelfRegister)) {
@@ -330,6 +498,61 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     @Override
     public boolean canChangePassword(Context context, EPerson ePerson, String currentPassword) {
         return false;
+    }
+
+    /**
+     * Decodes a JWT string and returns its header and payload as structured maps.
+     *
+     * <p>
+     * ⚠️ This decoder is designed for JWTs (RFC 7519), not JWEs (RFC 7516).
+     * JWEs are encrypted and require decryption before decoding.
+     * </p>
+     * @param jwt the JWT string in the format {@code header.payload.signature}
+     * @return a map containing two entries:
+     *         <ul>
+     *             <li>{@code "header"} → decoded JWT header as a map</li>
+     *             <li>{@code "payload"} → decoded JWT payload as a map</li>
+     *         </ul>
+     * 
+     * @throws IllegalArgumentException if the JWT format is invalid or decoding fails
+     */
+    private static Map<String, Map<String, Object>> decodeJwt(String jwt) {
+        String[] parts = jwt.split("\\.");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid JWT format");
+        }
+       
+        Map<String, Map<String, Object>> result = new HashMap<>();
+        result.put("header", parseJson(parts[0]));
+        result.put("payload", parseJson(parts[1]));
+
+        return result;
+    }
+
+    /**
+     * Decodes a Base64URL-encoded JWT section and parses it into a map.
+     *
+     * @param base64Url the Base64URL-encoded string
+     * @return a map representing the decoded JSON object
+     * @throws IllegalArgumentException if decoding or parsing fails
+     */
+    private static Map<String, Object> parseJson(String base64Url) {
+        String json = new String(Base64.getUrlDecoder().decode(padBase64(base64Url)));
+        JSONObject jsonObject = new JSONObject(json);
+
+        return jsonObject.toMap();
+    }
+
+    /**
+     * Pads a Base64URL string to ensure it has correct length for decoding.
+     *
+     * @param base64 the unpadded Base64URL string
+     * @return a padded Base64URL string suitable for decoding
+     */
+    private static String padBase64(String base64) {
+        int padding = 4 - (base64.length() % 4);
+
+        return base64 + "=".repeat(padding % 4);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -118,16 +118,6 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
         LOGGER.info("Getting special groups");
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        LOGGER.info("Authentication: {}", authentication);
-
-        LOGGER.info("Authentication name: {}", authentication.getName());
-
-        LOGGER.info("Authentication credentials: {}", authentication.getCredentials());
-        LOGGER.info("Authentication details: {}", authentication.getDetails());
-        LOGGER.info("Authentication principal: {}", authentication.getPrincipal());
-
         final List<Group> groups = new ArrayList<>();
 
         try {
@@ -149,11 +139,29 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
             Set<String> groupNames = new HashSet<>();
 
-            Cookie cookie = WebUtils.getCookie(request, "specialgroups");
-            if (cookie != null) {
-                String specialGroups = cookie.getValue();
-                if (specialGroups != null && specialGroups.length() > 0) {
-                    groupNames = Set.of(specialGroups.split(":"));
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            LOGGER.info("Authentication: {}", authentication);
+
+            LOGGER.info("Authentication name: {}", authentication.getName());
+
+            LOGGER.info("Authentication credentials: {}", authentication.getCredentials());
+            LOGGER.info("Authentication details: {}", authentication.getDetails());
+            LOGGER.info("Authentication principal: {}", authentication.getPrincipal());
+
+            if (authentication.getDetails() != null) {
+                groupNames = (Set<String>) authentication.getDetails();
+                LOGGER.info("Determining Special Groups (authentication details) " + groupNames);
+            }
+
+            if (groupNames.isEmpty()) {
+                Cookie cookie = WebUtils.getCookie(request, "specialgroups");
+                if (cookie != null) {
+                    String specialGroups = cookie.getValue();
+                    if (specialGroups != null && specialGroups.length() > 0) {
+                        groupNames = Set.of(specialGroups.split(":"));
+                        LOGGER.info("Determining Special Groups (session cookie) " + groupNames);
+                    }
                 }
             }
 
@@ -222,6 +230,8 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     }
 
     private int authenticateWithOidc(Context context, String code, HttpServletRequest request) throws SQLException {
+
+        // TODO: cleanup according to selected functional implementation
 
         OidcTokenResponseDTO accessToken = getOidcAccessToken(code);
         if (accessToken == null) {
@@ -409,6 +419,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         return configurationService.getProperty("authentication-oidc.user-info.last-name", "family_name");
     }
 
+    // TODO: add JavaDocs and update logging (debug)
     private Map<String, Map<String, String[]>> getGroupMappings() {
         final Map<String, Map<String, String[]>> groupMappings = new HashMap<>();
 
@@ -435,6 +446,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         return groupMappings;
     }
 
+    // TODO: add JavaDocs and update logging (debug)
     private Map<String, String[]> getGroupMapping(String claimKey) {
         final Map<String, String[]> groupMapping = new HashMap<>();
 
@@ -481,6 +493,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         return groupMapping;
     }
 
+    // TODO: add JavaDocs and logging (debug)
     private Set<String> determineGroups(Map<String, Map<String, String[]>> groupMappings, Map<String, Object> claims) {
         final Set<String> groups = new HashSet<>();
 
@@ -564,6 +577,8 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     public boolean canChangePassword(Context context, EPerson ePerson, String currentPassword) {
         return false;
     }
+
+    // TODO: look for existing utility for JWT and possible JWE otherwise move into a simple utility class
 
     /**
      * Decodes a JWT string and returns its header and payload as structured maps.

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,6 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authenticate.oidc.OidcClient;
 import org.dspace.authenticate.oidc.model.OidcTokenResponseDTO;
+import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -51,6 +53,9 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.web.ContextUtil;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.util.WebUtils;
 
 /**
  * OpenID Connect Authentication for DSpace.
@@ -85,6 +90,9 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     @Autowired
     private EPersonService ePersonService;
 
+    @Autowired
+    private MetadataValueService metadataValueService;
+
     @Override
     public boolean allowSetPassword(Context context, HttpServletRequest request, String username) throws SQLException {
         return false;
@@ -110,48 +118,71 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
         LOGGER.info("Getting special groups");
 
-        if (context.getSpecialGroups().size() > 0 ) {
-            LOGGER.info("Returning cached special groups.");
-            return context.getSpecialGroups();
-        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        LOGGER.info("Authentication: {}", authentication);
+
+        LOGGER.info("Authentication name: {}", authentication.getName());
+
+        LOGGER.info("Authentication credentials: {}", authentication.getCredentials());
+        LOGGER.info("Authentication details: {}", authentication.getDetails());
+        LOGGER.info("Authentication principal: {}", authentication.getPrincipal());
 
         final List<Group> groups = new ArrayList<>();
 
         try {
-            if (context.getCurrentUser() != null) {
+            if (request == null || context.getCurrentUser() == null) {
+                return Collections.EMPTY_LIST;
+            }
 
-                String code = (String) request.getParameter("code");
-                if (StringUtils.isEmpty(code)) {
-                    LOGGER.warn("The incoming request does not have a code parameter");
+            if (context.getSpecialGroups().size() > 0) {
+                LOGGER.info("Returning cached special groups.");
+                return context.getSpecialGroups();
+            }
+
+            String code = (String) request.getParameter("code");
+            if (StringUtils.isEmpty(code)) {
+                LOGGER.warn("The incoming request does not have a code parameter");
+            }
+
+            printRequestDetails(request);
+
+            Set<String> groupNames = new HashSet<>();
+
+            Cookie cookie = WebUtils.getCookie(request, "specialgroups");
+            if (cookie != null) {
+                String specialGroups = cookie.getValue();
+                if (specialGroups != null && specialGroups.length() > 0) {
+                    groupNames = Set.of(specialGroups.split(":"));
                 }
+            }
 
-                printRequestDetails(request);
-
-                Set<String> groupNames = threadLocalGroupNames.get();
+            if (groupNames.isEmpty()) {
+                groupNames = threadLocalGroupNames.get();
                 LOGGER.info("Determining Special Groups (thread local) " + groupNames);
+            }
 
-                if (groupNames.isEmpty()) {
-                    groupNames = context.getSpecialGroupNames();
-                    LOGGER.info("Determining Special Groups (context) " + groupNames);
+            if (groupNames.isEmpty()) {
+                groupNames = context.getSpecialGroupNames();
+                LOGGER.info("Determining Special Groups (context) " + groupNames);
+            }
+
+            if (groupNames.isEmpty()) {
+                groupNames = ContextUtil.obtainContext(request).getSpecialGroupNames();
+                LOGGER.info("Determining Special Groups (request context) " + groupNames);
+            }
+
+            for (String groupName : groupNames) {
+                if (groupName == null || groupName.isEmpty()) {
+                    continue;
                 }
-
-                if (groupNames.isEmpty()) {
-                    groupNames = ContextUtil.obtainContext(request).getSpecialGroupNames();
-                    LOGGER.info("Determining Special Groups (request context) " + groupNames);
-                }
-
-                for (String groupName : groupNames) {
-                    if (groupName == null || groupName.isEmpty()) {
-                        continue;
-                    }
-                    LOGGER.info("Looking Up Special Group " + groupName);
-                    Group group = groupService.findByName(context, groupName);
-                    if (group == null) {
-                        LOGGER.warn("Group {} does not exist", groupName);
-                    } else {
-                        LOGGER.info("Found Special Group " + groupName);
-                        groups.add(group);
-                    }
+                LOGGER.info("Looking Up Special Group " + groupName);
+                Group group = groupService.findByName(context, groupName);
+                if (group == null) {
+                    LOGGER.warn("Group {} does not exist", groupName);
+                } else {
+                    LOGGER.info("Found Special Group " + groupName);
+                    groups.add(group);
                 }
             }
         } catch (SQLException ex) {
@@ -241,11 +272,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         }
 
         // if self registration is disabled, warn about this failure to find a matching eperson
-        if (!canSelfRegister()) {
-            LOGGER.warn("Self registration is currently disabled for OIDC, and no ePerson could be found for email: {}",
-                email);
-            return NO_SUCH_USER;
-        } else {
+        if (canSelfRegister()) {
             int result = registerNewEPerson(context, userInfo, email);
             if (result == SUCCESS) {
                 // It is important to set this attribute so the new user
@@ -253,6 +280,10 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                 request.setAttribute(OIDC_AUTHENTICATED, true);
             }
             return result;
+        } else {
+            LOGGER.warn("Self registration is currently disabled for OIDC, and no ePerson could be found for email: {}",
+                email);
+            return NO_SUCH_USER;
         }
     }
 
@@ -591,6 +622,18 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     private static void printRequestDetails(HttpServletRequest request) {
         LOGGER.info("=== HTTP SERVLET REQUEST DETAILS ===");
+
+        LOGGER.info("--- ATTRIBUTES ---");
+        Enumeration<String> attributeNames = request.getAttributeNames();
+        if (!attributeNames.hasMoreElements()) {
+            LOGGER.info("No attributes found");
+        } else {
+            while (attributeNames.hasMoreElements()) {
+                String attributeName = attributeNames.nextElement();
+                Object attributeValue = request.getAttribute(attributeName);
+                LOGGER.info(attributeName + " = " + attributeValue);
+            }
+        }
 
         LOGGER.info("--- PARAMETERS ---");
         Enumeration<String> paramNames = request.getParameterNames();

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -123,7 +123,6 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                 String code = (String) request.getParameter("code");
                 if (StringUtils.isEmpty(code)) {
                     LOGGER.warn("The incoming request does not have a code parameter");
-                    return NO_SUCH_USER;
                 }
 
                 printRequestDetails(request);

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -119,8 +119,13 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
         printRequestDetails(request);
 
-        final Set<String> groupNames = Set.copyOf(threadLocalGroupNames.get());
-        LOGGER.info("Determining Special Groups " + groupNames);
+        Set<String> groupNames = threadLocalGroupNames.get();
+        LOGGER.info("Determining Special Groups (thread local) " + groupNames);
+
+        if (groupNames.isEmpty()) {
+            groupNames = context.getSpecialGroupNames();
+            LOGGER.info("Determining Special Groups (context) " + groupNames);
+        }
 
         final List<Group> groups = new ArrayList<>();
 
@@ -207,6 +212,10 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         LOGGER.info("Groups " + groups);
 
         threadLocalGroupNames.set(groups);
+
+        request.setAttribute("specialgroups", groups);
+
+        context.setSpecialGroupNames(groups);
 
 
         String email = getAttributeAsString(userInfo, getEmailAttribute());

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -134,11 +134,6 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
                     LOGGER.info("Determining Special Groups (request context) " + groupNames);
                 }
 
-                if (groupNames.isEmpty()) {
-                    groupNames = ContextUtil.obtainCurrentRequestContext().getSpecialGroupNames();
-                    LOGGER.info("Determining Special Groups (current request context) " + groupNames);
-                }
-
                 for (String groupName : groupNames) {
                     if (groupName == null || groupName.isEmpty()) {
                         continue;

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -32,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
@@ -104,13 +106,26 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) throws SQLException {
-        final Set<String> groupNames = threadLocalGroupNames.get();
+
+        if (context.getSpecialGroups().size() > 0 ) {
+            LOGGER.info("Returning cached special groups.");
+            return context.getSpecialGroups();
+        }
+
+        String code = (String) request.getParameter("code");
+        if (StringUtils.isEmpty(code)) {
+            LOGGER.info("The incoming request does not have a code parameter");
+        }
+
+        printRequestDetails(request);
+
+        final Set<String> groupNames = Set.copyOf(threadLocalGroupNames.get());
         LOGGER.info("Determining Special Groups " + groupNames);
 
-        List<Group> groups = new ArrayList<>();
+        final List<Group> groups = new ArrayList<>();
 
         try {
-            if (context.getCurrentUser() != null && groupNames != null) {
+            if (context.getCurrentUser() != null) {
                 for (String groupName : groupNames) {
                     if (groupName == null || groupName.isEmpty()) {
                         continue;
@@ -154,7 +169,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
         String code = (String) request.getParameter("code");
         if (StringUtils.isEmpty(code)) {
-            LOGGER.warn("The incoming request has not code parameter");
+            LOGGER.warn("The incoming request does not have a code parameter");
             return NO_SUCH_USER;
         }
 
@@ -553,6 +568,74 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         int padding = 4 - (base64.length() % 4);
 
         return base64 + "=".repeat(padding % 4);
+    }
+
+    private static void printRequestDetails(HttpServletRequest request) {
+        LOGGER.info("=== HTTP SERVLET REQUEST DETAILS ===");
+
+        LOGGER.info("--- PARAMETERS ---");
+        Enumeration<String> paramNames = request.getParameterNames();
+        if (!paramNames.hasMoreElements()) {
+            LOGGER.info("No parameters found");
+        } else {
+            while (paramNames.hasMoreElements()) {
+                String paramName = paramNames.nextElement();
+                String[] paramValues = request.getParameterValues(paramName);
+                if (paramValues.length == 1) {
+                    LOGGER.info(paramName + " = " + paramValues[0]);
+                } else {
+                    String message = paramName + " = [";
+                    for (int i = 0; i < paramValues.length; i++) {
+                        message += paramValues[i];
+                        if (i < paramValues.length - 1) {
+                            message += ", ";
+                        }
+                    }
+                    message += "]";
+                    LOGGER.info(message);
+                }
+            }
+        }
+
+        LOGGER.info("--- HEADERS ---");
+        Enumeration<String> headerNames = request.getHeaderNames();
+        if (!headerNames.hasMoreElements()) {
+            LOGGER.info("No headers found");
+        } else {
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                Enumeration<String> headerValues = request.getHeaders(headerName);
+
+                String message  = headerName + " = ";
+
+                boolean first = true;
+                while (headerValues.hasMoreElements()) {
+                    if (!first) {
+                        message += ", ";
+                    }
+                    message += headerValues.nextElement();
+                    first = false;
+                }
+                LOGGER.info(message);
+            }
+        }
+
+        LOGGER.info("--- COOKIES ---");
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            LOGGER.info("No cookies found");
+        } else {
+            for (Cookie cookie : cookies) {
+                LOGGER.info(cookie.getName() + " = " + cookie.getValue() +
+                    " (domain: " + cookie.getDomain() +
+                    ", path: " + cookie.getPath() +
+                    ", maxAge: " + cookie.getMaxAge() +
+                    ", secure: " + cookie.getSecure() +
+                    ", httpOnly: " + cookie.isHttpOnly() + ")");
+            }
+        }
+
+        LOGGER.info("=== END REQUEST DETAILS ===");
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -110,15 +110,15 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
         LOGGER.info("Getting special groups");
 
+        if (context.getSpecialGroups().size() > 0 ) {
+            LOGGER.info("Returning cached special groups.");
+            return context.getSpecialGroups();
+        }
+
         final List<Group> groups = new ArrayList<>();
 
         try {
             if (context.getCurrentUser() != null) {
-
-                if (context.getSpecialGroups().size() > 0 ) {
-                    LOGGER.info("Returning cached special groups.");
-                    return context.getSpecialGroups();
-                }
 
                 String code = (String) request.getParameter("code");
                 if (StringUtils.isEmpty(code)) {

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -48,6 +48,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
+import org.dspace.web.ContextUtil;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -65,10 +66,9 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     public static final String OIDC_AUTH_ATTRIBUTE = "oidc";
 
-    protected GroupService groupService
-            = EPersonServiceFactory.getInstance().getGroupService();
+    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
 
-    private final static String LOGIN_PAGE_URL_FORMAT = "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s";
+    private static final String LOGIN_PAGE_URL_FORMAT = "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s";
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -107,30 +107,38 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) throws SQLException {
 
-        if (context.getSpecialGroups().size() > 0 ) {
-            LOGGER.info("Returning cached special groups.");
-            return context.getSpecialGroups();
-        }
-
-        String code = (String) request.getParameter("code");
-        if (StringUtils.isEmpty(code)) {
-            LOGGER.info("The incoming request does not have a code parameter");
-        }
-
-        printRequestDetails(request);
-
-        Set<String> groupNames = threadLocalGroupNames.get();
-        LOGGER.info("Determining Special Groups (thread local) " + groupNames);
-
-        if (groupNames.isEmpty()) {
-            groupNames = context.getSpecialGroupNames();
-            LOGGER.info("Determining Special Groups (context) " + groupNames);
-        }
+        LOGGER.info("Getting special groups");
 
         final List<Group> groups = new ArrayList<>();
 
         try {
             if (context.getCurrentUser() != null) {
+
+                if (context.getSpecialGroups().size() > 0 ) {
+                    LOGGER.info("Returning cached special groups.");
+                    return context.getSpecialGroups();
+                }
+
+                printRequestDetails(request);
+
+                Set<String> groupNames = threadLocalGroupNames.get();
+                LOGGER.info("Determining Special Groups (thread local) " + groupNames);
+
+                if (groupNames.isEmpty()) {
+                    groupNames = context.getSpecialGroupNames();
+                    LOGGER.info("Determining Special Groups (context) " + groupNames);
+                }
+
+                if (groupNames.isEmpty()) {
+                    groupNames = ContextUtil.obtainContext(request).getSpecialGroupNames();
+                    LOGGER.info("Determining Special Groups (request context) " + groupNames);
+                }
+
+                if (groupNames.isEmpty()) {
+                    groupNames = ContextUtil.obtainCurrentRequestContext().getSpecialGroupNames();
+                    LOGGER.info("Determining Special Groups (current request context) " + groupNames);
+                }
+
                 for (String groupName : groupNames) {
                     if (groupName == null || groupName.isEmpty()) {
                         continue;
@@ -213,6 +221,7 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
         threadLocalGroupNames.set(groups);
 
+        request.setAttribute("code", code);
         request.setAttribute("specialgroups", groups);
 
         context.setSpecialGroupNames(groups);

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -89,6 +89,8 @@ public class Context implements AutoCloseable {
      */
     private Deque<String> authStateClassCallHistory;
 
+    private Set<String> specialGroupNames;
+
     /**
      * Group IDs of special groups user is a member of
      */
@@ -189,6 +191,7 @@ public class Context implements AutoCloseable {
         extraLogInfo = "";
         ignoreAuth = false;
 
+        specialGroupNames = new HashSet<>();
         specialGroups = new HashSet<>();
 
         authStateChangeHistory = new ConcurrentLinkedDeque<>();
@@ -659,6 +662,10 @@ public class Context implements AutoCloseable {
         return mode != null && mode == Mode.READ_ONLY;
     }
 
+    public void setSpecialGroupNames(Set<String> groupNames) {
+        specialGroupNames.addAll(groupNames);
+    }
+
     /**
      * Add a group's UUID to the list of special groups cached in Context
      * @param groupID UUID of group
@@ -675,6 +682,10 @@ public class Context implements AutoCloseable {
      */
     public boolean inSpecialGroup(UUID groupID) {
         return specialGroups.contains(groupID);
+    }
+
+    public Set<String> getSpecialGroupNames() {
+        return specialGroupNames;
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceAuthentication.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceAuthentication.java
@@ -30,6 +30,8 @@ public class DSpaceAuthentication implements Authentication {
     private List<GrantedAuthority> authorities;
     private boolean authenticated;
 
+    private Object details;
+
     /**
      * Create a DSpaceAuthentication instance for an already authenticated EPerson, including their GrantedAuthority
      * objects.
@@ -80,7 +82,11 @@ public class DSpaceAuthentication implements Authentication {
     }
 
     public Object getDetails() {
-        return null;
+        return details;
+    }
+
+    public void setDetails(Object details) {
+        this.details = details;
     }
 
     public Object getPrincipal() {
@@ -101,5 +107,24 @@ public class DSpaceAuthentication implements Authentication {
 
     public Instant getPreviousLoginDate() {
         return previousLoginDate;
+    }
+
+    DSpaceAuthentication forEPerson(EPerson ePerson) {
+         this.previousLoginDate = ePerson.getPreviousActive();
+         this.username = ePerson.getEmail();
+
+         return this;
+    }
+
+    DSpaceAuthentication withGrantedAuthorities(List<GrantedAuthority> authorities) {
+        this.authorities = authorities;
+
+        return this;
+    }
+
+    DSpaceAuthentication withAuthenticatedTrue() {
+        this.authenticated = true;
+
+        return this;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
@@ -81,11 +81,11 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
         if (context != null && context.getCurrentUser() != null) {
             // Simply refresh/reload the auth token. If token has expired, the token will change.
             log.debug("Request to refresh auth token");
-            return authenticateRefreshTokenRequest(context);
+            return authenticateRefreshTokenRequest(context, (DSpaceAuthentication) authentication);
         } else {
             // Otherwise, this is a new login & we need to attempt authentication
             log.debug("Request to authenticate new login");
-            return authenticateNewLogin(context, authentication);
+            return authenticateNewLogin(context, (DSpaceAuthentication) authentication);
         }
     }
 
@@ -97,9 +97,10 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
      * @param context current DSpace context (for currently logged in user information)
      * @return DSpaceAuthentication object representing authenticated user
      */
-    private Authentication authenticateRefreshTokenRequest(Context context) {
+    private Authentication authenticateRefreshTokenRequest(Context context, DSpaceAuthentication authentication) {
         authenticationService.updateLastActiveDate(context);
-        return createAuthentication(context);
+
+        return processAuthentication(context, authentication);
     }
 
     /**
@@ -112,8 +113,7 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
      * @param authentication Authentication class to attempt authentication.
      * @return new Authentication class containing logged-in user information or null
      */
-    private Authentication authenticateNewLogin(Context context, Authentication authentication) {
-        Authentication output = null;
+    private Authentication authenticateNewLogin(Context context, DSpaceAuthentication authentication) {
 
         if (authentication != null) {
             String name = authentication.getName();
@@ -123,14 +123,14 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
 
             if (implicitStatus == AuthenticationMethod.SUCCESS) {
                 log.info(LogHelper.getHeader(context, "login", "type=implicit"));
-                output = createAuthentication(context);
+                processAuthentication(context, authentication);
             } else {
                 int authenticateResult = authenticationService.authenticate(context, name, password, null, request);
                 if (AuthenticationMethod.SUCCESS == authenticateResult) {
 
                     log.info(LogHelper.getHeader(context, "login", "type=explicit"));
 
-                    output = createAuthentication(context);
+                    processAuthentication(context, authentication);
 
                     for (PostLoggedInAction action : postLoggedInActions) {
                         try {
@@ -148,26 +148,27 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
             }
         }
 
-        return output;
+        return authentication;
     }
 
     /**
-     * Create a valid Spring Authentication object for the user currently authenticated in the Context.
+     * Process existing valid Spring Authentication object for the user currently authenticated in the Context.
      * If no current user is found in the Context, then the login must have failed and a BadCredentialsException is
      * thrown.
      * @param context current DSpace context
      * @return DSpaceAuthentication object for currently authenticated user
      * @throws BadCredentialsException if no current user found
      */
-    private Authentication createAuthentication(final Context context) {
+    private Authentication processAuthentication(final Context context, final DSpaceAuthentication authentication) {
         EPerson ePerson = context.getCurrentUser();
 
         if (ePerson != null && StringUtils.isNotBlank(ePerson.getEmail())) {
             //Pass the eperson ID to the request service
             requestService.setCurrentUserId(ePerson.getID());
 
-            return new DSpaceAuthentication(ePerson, getGrantedAuthorities(context));
-
+            return authentication.forEPerson(ePerson)
+                .withGrantedAuthorities(getGrantedAuthorities(context))
+                .withAuthenticatedTrue();
         } else {
             log.info(LogHelper.getHeader(context, "failed_login", "No eperson with a non-blank e-mail address found"));
             throw new BadCredentialsException("Login failed");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.security.WebSecurityConfiguration.OidcWebAuthenticationDetails;
 import org.dspace.core.Utils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -53,7 +54,25 @@ public class OidcLoginFilter extends StatelessLoginFilter {
         throws AuthenticationException {
         req.setAttribute(OIDC_AUTH_ATTRIBUTE, OIDC_AUTH_ATTRIBUTE);
         // NOTE: because this authentication is implicit, we pass in an empty DSpaceAuthentication
-        return authenticationManager.authenticate(new DSpaceAuthentication());
+
+        // :( why was this method returning a new authentication object?
+        Authentication authentication = authenticationManager.authenticate(new DSpaceAuthentication());
+
+        // NOTE: this is a cross module knowledge via request attribute
+        // Authentication setting details from the request must occur after dspace-api OidcAuthentcationBean
+        // authenticate in which places the specialgroups attribute on the request
+        OidcWebAuthenticationDetails oidcWebAuthenticationDetails = (OidcWebAuthenticationDetails) authenticationDetailsSource.buildDetails(req);
+        log.info("OIDC Web Authentication Details: {}", oidcWebAuthenticationDetails);
+
+        Object details = oidcWebAuthenticationDetails.getDetails();
+        log.info("details: {}", details);
+
+        ((DSpaceAuthentication) authentication).setDetails(details);
+
+
+        log.info("Authentication details: {}", authentication.getDetails());
+
+        return authentication;
     }
 
     @Override
@@ -61,7 +80,7 @@ public class OidcLoginFilter extends StatelessLoginFilter {
         Authentication auth) throws IOException, ServletException {
         restAuthenticationService.addAuthenticationDataForUser(req, res, (DSpaceAuthentication) auth, true);
 
-        // NOTE: this is a cross module coupling
+        // NOTE: this is a cross module knowledge via request attribute
         // dspace-api OidcAuthenticationBean authenticate adds the determined special groups to the request attribute
         // this spring security filter on success adds the special groups as a response cookie
         log.info("--- ATTRIBUTES filter successful authentication ---");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
@@ -61,6 +61,9 @@ public class OidcLoginFilter extends StatelessLoginFilter {
         Authentication auth) throws IOException, ServletException {
         restAuthenticationService.addAuthenticationDataForUser(req, res, (DSpaceAuthentication) auth, true);
 
+        // NOTE: this is a cross module coupling
+        // dspace-api OidcAuthenticationBean authenticate adds the determined special groups to the request attribute
+        // this spring security filter on success adds the special groups as a response cookie
         log.info("--- ATTRIBUTES filter successful authentication ---");
         Enumeration<String> attributeNames = req.getAttributeNames();
         if (!attributeNames.hasMoreElements()) {
@@ -81,7 +84,7 @@ public class OidcLoginFilter extends StatelessLoginFilter {
         log.info("Path (filter successful authentication): {}", path);
 
         Cookie specialGroupsCookie = new Cookie("specialgroups", specialGroups);
-        specialGroupsCookie.setMaxAge(7200);
+        specialGroupsCookie.setMaxAge(-1);
         specialGroupsCookie.setPath(path);
         specialGroupsCookie.setHttpOnly(true);
         specialGroupsCookie.setSecure(true);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
@@ -11,9 +11,12 @@ import static org.dspace.authenticate.OidcAuthenticationBean.OIDC_AUTH_ATTRIBUTE
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Set;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
@@ -57,6 +60,35 @@ public class OidcLoginFilter extends StatelessLoginFilter {
     protected void successfulAuthentication(HttpServletRequest req, HttpServletResponse res, FilterChain chain,
         Authentication auth) throws IOException, ServletException {
         restAuthenticationService.addAuthenticationDataForUser(req, res, (DSpaceAuthentication) auth, true);
+
+        log.info("--- ATTRIBUTES filter successful authentication ---");
+        Enumeration<String> attributeNames = req.getAttributeNames();
+        if (!attributeNames.hasMoreElements()) {
+            log.info("No attributes found");
+        } else {
+            while (attributeNames.hasMoreElements()) {
+                String attributeName = attributeNames.nextElement();
+                Object attributeValue = req.getAttribute(attributeName);
+                log.info(attributeName + " = " + attributeValue);
+            }
+        }
+        log.info("--- END ATTRIBUTES filter successful authentication ---");
+
+        String specialGroups = String.join(":", (Set<String>) req.getAttribute("specialgroups"));
+        String path = req.getContextPath();
+
+        log.info("Special groups (filter successful authentication): {}", specialGroups);
+        log.info("Path (filter successful authentication): {}", path);
+
+        Cookie specialGroupsCookie = new Cookie("specialgroups", specialGroups);
+        specialGroupsCookie.setMaxAge(7200);
+        specialGroupsCookie.setPath(path);
+        specialGroupsCookie.setHttpOnly(true);
+        specialGroupsCookie.setSecure(true);
+        specialGroupsCookie.setAttribute("SameSite", "Strict");
+
+        res.addCookie(specialGroupsCookie);
+
         redirectAfterSuccess(req, res);
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -12,6 +12,7 @@ import java.util.Enumeration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.DSpaceAccessDeniedHandler;
+import org.dspace.app.rest.security.WebSecurityConfiguration.OidcWebAuthenticationDetails;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.services.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,6 +99,14 @@ public class WebSecurityConfiguration {
         // Get the current AuthenticationManager (defined above) to apply filters below
         AuthenticationManager authenticationManager = authenticationManager();
 
+        // TODO: move into a method
+        OidcLoginFilter oidcLoginFilter = new OidcLoginFilter("/api/authn/oidc", HttpMethod.GET.name(),
+            authenticationManager, restAuthenticationService);
+        oidcLoginFilter.setAuthenticationDetailsSource(oidcAuthenticationDetailsSource());
+
+        // TODO: Create all login filters similar to above and add to security filter chain respecting the configured
+        // authentication method order
+
         // Configure authentication requirements for ${dspace.server.url}/api/ URL only
         // NOTE: REST API is hardcoded to respond on /api/. Other modules (OAI, SWORD, IIIF, etc) use other root paths.
         http.securityMatcher("/api/**", "/iiif/**", actuatorBasePath + "/**", "/signposting/**")
@@ -168,9 +177,7 @@ public class WebSecurityConfiguration {
             // Add a filter before our OIDC endpoints to do the authentication based on the data in the HTTP request.
             // This endpoint only responds to GET as the actual authentication is performed by OIDC, which then
             // redirects to this endpoint to forward the authentication data to DSpace.
-            .addFilterBefore(new OidcLoginFilter("/api/authn/oidc", HttpMethod.GET.name(),
-                                                 authenticationManager, restAuthenticationService),
-                             LogoutFilter.class)
+            .addFilterBefore(oidcLoginFilter, LogoutFilter.class)
             // Add a filter before our SAML endpoints to do the authentication based on the data in the HTTP request.
             // This endpoint only responds to GET as the actual authentication is performed by SAML, which then
             // forwards to this endpoint to pass the authentication data to DSpace.
@@ -218,16 +225,15 @@ public class WebSecurityConfiguration {
         return new DSpaceCsrfAuthenticationStrategy(csrfTokenRepository());
     }
 
-    @Bean
-    public AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> authenticationDetailsSource() {
-        return request -> new CustomWebAuthenticationDetails(request);
+    public AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> oidcAuthenticationDetailsSource() {
+        return request -> new OidcWebAuthenticationDetails(request);
     }
 
-    public class CustomWebAuthenticationDetails extends WebAuthenticationDetails {
+    public class OidcWebAuthenticationDetails extends WebAuthenticationDetails {
 
         private final Object extraDetail;
 
-        public CustomWebAuthenticationDetails(HttpServletRequest request) {
+        public OidcWebAuthenticationDetails(HttpServletRequest request) {
             super(request);
 
             log.info("--- ATTRIBUTES custom web authentication details ---");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -99,7 +99,7 @@ public class WebSecurityConfiguration {
         // Get the current AuthenticationManager (defined above) to apply filters below
         AuthenticationManager authenticationManager = authenticationManager();
 
-        // TODO: move into a method
+        // TODO: move into a method and use constants for paths
         OidcLoginFilter oidcLoginFilter = new OidcLoginFilter("/api/authn/oidc", HttpMethod.GET.name(),
             authenticationManager, restAuthenticationService);
         oidcLoginFilter.setAuthenticationDetailsSource(oidcAuthenticationDetailsSource());
@@ -226,12 +226,21 @@ public class WebSecurityConfiguration {
     }
 
     public AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> oidcAuthenticationDetailsSource() {
-        return request -> new OidcWebAuthenticationDetails(request);
+        // TODO: move into appropriate package and instantiate without method in WebSecurityConfig
+        return new AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails>() {
+
+            @Override
+            public WebAuthenticationDetails buildDetails(HttpServletRequest request) {
+                return new OidcWebAuthenticationDetails(request);
+            }
+
+        };
     }
 
+    // TODO: move into appropriate package and type details using generics
     public class OidcWebAuthenticationDetails extends WebAuthenticationDetails {
 
-        private final Object extraDetail;
+        private final Object details;
 
         public OidcWebAuthenticationDetails(HttpServletRequest request) {
             super(request);
@@ -249,11 +258,12 @@ public class WebSecurityConfiguration {
             }
             log.info("--- END ATTRIBUTES custom web authentication details ---");
 
-            this.extraDetail = request.getAttribute("specialgroups");
+            // TODO: find or create constant for specialgroups
+            this.details = request.getAttribute("specialgroups");
         }
 
-        public Object getExtraDetail() {
-            return extraDetail;
+        public Object getDetails() {
+            return details;
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -7,6 +7,10 @@
  */
 package org.dspace.app.rest.security;
 
+import java.util.Enumeration;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.DSpaceAccessDeniedHandler;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.services.RequestService;
@@ -19,6 +23,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.Customizer;
@@ -26,11 +31,14 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Spring Security configuration for DSpace Server Webapp
@@ -42,6 +50,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @Configuration
 @EnableConfigurationProperties(SecurityProperties.class)
 public class WebSecurityConfiguration {
+
+    private static final Logger log = LogManager.getLogger(WebSecurityConfiguration.class);
 
     public static final String ADMIN_GRANT = "ADMIN";
     public static final String AUTHENTICATED_GRANT = "AUTHENTICATED";
@@ -206,6 +216,39 @@ public class WebSecurityConfiguration {
     @Bean
     public DSpaceCsrfAuthenticationStrategy dSpaceCsrfAuthenticationStrategy() {
         return new DSpaceCsrfAuthenticationStrategy(csrfTokenRepository());
+    }
+
+    @Bean
+    public AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> authenticationDetailsSource() {
+        return request -> new CustomWebAuthenticationDetails(request);
+    }
+
+    public class CustomWebAuthenticationDetails extends WebAuthenticationDetails {
+
+        private final Object extraDetail;
+
+        public CustomWebAuthenticationDetails(HttpServletRequest request) {
+            super(request);
+
+            log.info("--- ATTRIBUTES custom web authentication details ---");
+            Enumeration<String> attributeNames = request.getAttributeNames();
+            if (!attributeNames.hasMoreElements()) {
+                log.info("No attributes found");
+            } else {
+                while (attributeNames.hasMoreElements()) {
+                    String attributeName = attributeNames.nextElement();
+                    Object attributeValue = request.getAttribute(attributeName);
+                    log.info(attributeName + " = " + attributeValue);
+                }
+            }
+            log.info("--- END ATTRIBUTES custom web authentication details ---");
+
+            this.extraDetail = request.getAttribute("specialgroups");
+        }
+
+        public Object getExtraDetail() {
+            return extraDetail;
+        }
     }
 
 }

--- a/dspace/config/modules/authentication-oidc.cfg
+++ b/dspace/config/modules/authentication-oidc.cfg
@@ -38,11 +38,36 @@ authentication-oidc.scopes = openid,email,profile
 # leave this set to true.
 authentication-oidc.can-self-register = true
 
-#Specify the attribute present in the user info json related to the user's email
+# Specify the attribute present in the user info json related to the user's email
 authentication-oidc.user-info.email = email
 
-#Specify the attribute present in the user info json related to the user's first name
+# Specify the attribute present in the user info json related to the user's first name
 authentication-oidc.user-info.first-name = given_name
 
-#Specify the attribute present in the user info json related to the user's last name
+# Specify the attribute present in the user info json related to the user's last name
 authentication-oidc.user-info.last-name = family_name
+
+
+# Specify special groups mapping. Special group assignments are temporary and not persisted. 
+
+# For configured claim from OIDC identity (`id`) token's payload, assign to a specific group
+# or groups (comma separated list of groups).
+
+# The claim keys used to compare with configured mapping.
+# authentication-oidc.group.claims = <claims to associate to a group>
+
+# Dynamic configuration comprised of claims defined by `authentication-oidc.group.claims` and
+# the value that must match the OIDC identity claim value starting with. The configuration value 
+# being which special group the authenticated EPerson will be a member of.
+# authentication-oidc.<claim>.<value> = <groups>
+
+# Example with OIDC groups claims.
+# authentication-oidc.group.claims = groups
+
+# If an OIDC authenticated identity is in group affiliation_employee@scope.domain,
+# affiliation_faculty@scope.domain, etc., then assign to special group Employee, Faculty, etc. respectively.
+# authentication-oidc.groups.affiliation_employee = Employee
+# authentication-oidc.groups.affiliation_faculty = Faculty
+# authentication-oidc.groups.affiliation_member = Member
+# authentication-oidc.groups.affiliation_staff = Staff
+# authentication-oidc.groups.affiliation_student = Student

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -114,5 +114,14 @@
         <scope_note>Metadata field storing the user-configured accessibility settings values for the EPerson.</scope_note>
     </dc-type>
 
+    <!-- TAMU Customization - EPerson metadata for last OIDC last known ID token -->
+    <dc-type>
+        <schema>dspace</schema>
+        <element>oidc</element>
+        <qualifier>id</qualifier>
+        <scope_note>Metadata field storing the last known ID token from OIDC authentication values for the EPerson.</scope_note>
+    </dc-type>
+    <!-- END TAMU Customization - EPerson metadata for last OIDC last known ID token -->
+
 
 </dspace-dc-types>


### PR DESCRIPTION
This draft PR demonstrates several approaches to attempt implementing OIDC special groups mapping as close to feature parity with Shibboleth as possible. Excluding the yet to be implemented additional attributes to EPerson metadata mapping.

As Shibboleth is a proxy which intercepts request to authentication with external service provider and OIDC is an external service provide that DSpace interacts with directly, the authenticate methods of the OidcAuthenticationBean must pass the claims from OIDC somehow to be used in getSpecialGroups group mapping.  Whereas ShibbolethAuthentication relies on Shibboleth headers on the request for special groups mapping of the current EPerson on the Context.

First approach was to try and pass the special groups on the HttpServletRequest between authenticate and getSpecialGroups. This did not work. Requests where not the same.

Second approach was to try and pass the special groups on the DSpace Context between authenticate and getSpecialGroups. This did not work. Contexts where not the same.

Third approach was to try using ThreadLocal to pass the special groups on the DSpace Context between authenticate and getSpecialGroups. This worked once with a fluke race condition. Threads are not the same.

Fourth approach was to consider persisting the last OIDC id token on the EPerson metadata. This could work but would be stateful and require schedule tasks to cleanup. Instead of continuing with this option I moved on but think it might be a good idea to append the OIDC id token on EPerson metadata tracking changes in identity.

Fifth approach was to use a session cookie to pass the special groups from the dspace-api OidcAuthenticationBean authenticate method request attribute to dspace-server-webapp OidcLoginFilter successfulAuthentication session cookie to the dspace-api OidcAuthenticationBean getSpecialGroups. This works with minimal code changes. However, it presents a disconnect between the OIDC session and it stores an additional session cookie in the browser and may require additional cookie management on logout.

Sixth approach is to use Spring security Authentication details that is set via AuthenticationDetailsSource the special groups in OidcLoginFilter authenticate after invoking the EPersonRestAuthenticationProvider authenticate which invokes the AuthenticationService authenticate which invokes the AuthenticationMethod authenticate and sets the special groups attribute on the request which is then placed as details on the Spring security Authentication that is then able to be used in the OidcAuthenticationBean getSpecialGroups.

This does not yet work just yet. 

So far, required correcting an instance of  EPersonRestAuthenticationProvider from instantiating another Authentication object that caused a dropped pointer between the login filter and the authentication provider. Additionally, I discovered it may be a good idea to append the login filters on the Spring security chain respecting the stacked order defined in configuration. Potentially not adding login filters for authentication methods that are not enabled. At may at some point not require the iteration within the AuthenticationService over the AuthenticationMethod instances.

In progress with ensuring a single reference to the SecurityContext Authentication is managed throughout the filter security chain instead of creating a new one in each `AbstractAuthenticationProcessingFilter` and another again in the StatelessAuthenticationFilter in which is finally placed in the SecurityContextHolder.

I recommend using the authentication details for storing special groups. Requires an addition of spring-security-starter in dspace-api where it was not required before. This is to use the SecurityContext and retrieve the Authentication and its Principal, Details, and Credentials.

The next steps could be to utilize AuthenticationDetailsSource for all `AbstractAuthenticationProcessingFilter` and aggregate the authentication details; such as combine all special groups from each or any additional details from identity providers. Then remove the iteration over authentication methods that each security filter iterates over.  This would require adding the security filters in the order defined in config.

Any additional suggested approaches are welcome, and I can attempt to implement and test.
