### PR TITLE
Pull upstream bug fix about the subscription-send script bug.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/FrequencyType.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/FrequencyType.java
@@ -12,12 +12,10 @@ import static java.time.temporal.TemporalAdjusters.previousOrSame;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
 import org.apache.commons.codec.binary.StringUtils;
@@ -46,15 +44,13 @@ public enum FrequencyType {
             case "D":
                 // Frequency is anything updated yesterday.
                 // startDate is beginning of day yesterday
-                Instant startOfYesterday = ZonedDateTime.now(ZoneOffset.UTC)
-                                                        .minus(1, ChronoUnit.DAYS)
-                                                        .with(LocalDateTime.MIN)
+                Instant startOfYesterday = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1)
+                                                        .with(LocalTime.MIN)
                                                         .toInstant();
                 startDate = startOfYesterday.toString();
                 // endDate is end of day yesterday
-                Instant endOfYesterday = ZonedDateTime.now(ZoneOffset.UTC)
-                                                      .minus(1, ChronoUnit.DAYS)
-                                                      .with(LocalDateTime.MAX)
+                Instant endOfYesterday = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1)
+                                                      .with(LocalTime.MAX)
                                                       .toInstant();
                 endDate = endOfYesterday.toString();
                 break;
@@ -77,17 +73,15 @@ public enum FrequencyType {
             case "W":
                 // Frequency is anything updated last week
                 // startDate is beginning of last week (Sunday, beginning of the day)
-                Instant startOfLastWeek = ZonedDateTime.now(ZoneOffset.UTC)
-                                                       .minus(1, ChronoUnit.WEEKS)
+                Instant startOfLastWeek = ZonedDateTime.now(ZoneOffset.UTC).minusWeeks(1)
                                                        .with(previousOrSame(DayOfWeek.SUNDAY))
-                                                       .with(LocalDateTime.MIN)
+                                                       .with(LocalTime.MIN)
                                                        .toInstant();
                 startDate = startOfLastWeek.toString();
                 // End date is end of last week (Saturday, end of day)
-                Instant endOfLastWeek = ZonedDateTime.now(ZoneOffset.UTC)
-                                                     .minus(1, ChronoUnit.WEEKS)
+                Instant endOfLastWeek = ZonedDateTime.now(ZoneOffset.UTC).minusWeeks(1)
                                                      .with(nextOrSame(DayOfWeek.SATURDAY))
-                                                     .with(LocalDateTime.MAX)
+                                                     .with(LocalTime.MAX)
                                                      .toInstant();
                 endDate = endOfLastWeek.toString();
                 break;


### PR DESCRIPTION
This is the upstream fix https://github.com/DSpace/DSpace/pull/11002 , our fork was created prior to this change.

### Quick Overview

The original codes' calculation of date botched the `[dspace]/bin/dspace subscription-send -f D` and `[dspace]/bin/dspace subscription-send -f W` (daily and weekly) cron scripts. The date range it calculated to form the solr queries (the `lastModified` field) ended up something like this:

```
...&fq=lastModified:[-999999999-01-01T00:00:00Z+TO+%2B999999999-12-31T23:59:59.999999999Z]...
```

and solr wouldn't take the query (`long overflow` because of the 999999999 stuff) :

```
org.dspace.discovery.SearchServiceException: Error from server at http://dspace-solr:8983/solr/search: long overflow
        at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:732)
        at org.dspace.subscriptions.objectupdates.CollectionUpdates.findUpdates(CollectionUpdates.java:42)
        at org.dspace.subscriptions.SubscriptionEmailNotificationServiceImpl.perform(SubscriptionEmailNotificationServiceImpl.java:94)
        at org.dspace.subscriptions.SubscriptionEmailNotification.internalRun(SubscriptionEmailNotification.java:60)
        at org.dspace.scripts.DSpaceRunnable.run(DSpaceRunnable.java:150)
        at org.dspace.app.launcher.ScriptLauncher.executeScript(ScriptLauncher.java:154)
        at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:132)
        at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:99)
Caused by: org.apache.solr.client.solrj.impl.HttpSolrClient$RemoteSolrException: Error from server at http://dspace-solr:8983/solr/search: long overflow
        at org.apache.solr.client.solrj.impl.HttpSolrClient.executeMethod(HttpSolrClient.java:681)
        at org.apache.solr.client.solrj.impl.HttpSolrClient.request(HttpSolrClient.java:266)
        at org.apache.solr.client.solrj.impl.HttpSolrClient.request(HttpSolrClient.java:248)
        at org.apache.solr.client.solrj.SolrRequest.process(SolrRequest.java:225)
        at org.apache.solr.client.solrj.SolrClient.query(SolrClient.java:1035)
        at org.apache.solr.client.solrj.SolrClient.query(SolrClient.java:1051)
        at org.dspace.discovery.SolrServiceImpl.retrieveResult(SolrServiceImpl.java:953)
        at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:729)
        ... 7 more
```

I've tested on our deployments that the fix works.
