### PR TITLE
Check for null resourcepolicy group in tamu customization full text

### DIFF
--- a/dspace/modules/additions/src/main/java/org/dspace/discovery/FullTextContentStreams.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/discovery/FullTextContentStreams.java
@@ -111,7 +111,7 @@ public class FullTextContentStreams extends ContentStreamBase {
                             ChronoLocalDate start = rp.getStartDate();
                             ChronoLocalDate end = rp.getEndDate();
                             ChronoLocalDate now = LocalDate.now();
-                            if (rp.getGroup().getName().equalsIgnoreCase("anonymous")
+                            if (rp.getGroup() != null && rp.getGroup().getName().equalsIgnoreCase("anonymous")
                                 && (start == null || ((start.isBefore(now) || start.isEqual(now))
                                 && (end == null || (end.isAfter(now) || now.isEqual(end)))))
                             ) {


### PR DESCRIPTION
The getGroup call can return null, so check for that to prevent stack traces.